### PR TITLE
Fix scroll position bug

### DIFF
--- a/lib/go-to-line-view.coffee
+++ b/lib/go-to-line-view.coffee
@@ -66,10 +66,10 @@ class GoToLineView extends View
       column = -1
 
     position = new Point(row, column)
-    editor.scrollToBufferPosition(position, center: true)
     editor.setCursorBufferPosition(position)
     if column < 0
       editor.moveToFirstCharacterOfLine()
+    editor.scrollToBufferPosition(position, center: true)
 
   storeFocusedElement: ->
     @previouslyFocusedElement = $(':focus')

--- a/spec/fixtures/sample.js
+++ b/spec/fixtures/sample.js
@@ -11,3 +11,60 @@ var quicksort = function () {
 
   return sort(Array.apply(this, arguments));
 };
+
+// adapted from:
+// https://github.com/nzakas/computer-science-in-javascript/tree/master/algorithms/sorting/merge-sort-recursive
+var mergeSort function (items){
+  var merge = function (left, right){
+    var result  = [];
+    var il = 0;
+    var ir = 0;
+
+    while (il < left.length && ir < right.length){
+      if (left[il] < right[ir]){
+        result.push(left[il++]);
+      } else {
+        result.push(right[ir++]);
+      }
+    }
+
+    return result.concat(left.slice(il)).concat(right.slice(ir));
+  };
+
+  if (items.length < 2) {
+    return items;
+  }
+
+  var middle = Math.floor(items.length / 2),
+  left    = items.slice(0, middle),
+  right   = items.slice(middle),
+  params = merge(mergeSort(left), mergeSort(right));
+
+  // Add the arguments to replace everything between 0 and last item in the array
+  params.unshift(0, items.length);
+  items.splice.apply(items, params);
+  return items;
+};
+
+// adapted from:
+// https://github.com/nzakas/computer-science-in-javascript/blob/master/algorithms/sorting/bubble-sort/bubble-sort.js
+var bubbleSort = function (items){
+  var swap = function (items, firstIndex, secondIndex){
+    var temp = items[firstIndex];
+    items[firstIndex] = items[secondIndex];
+    items[secondIndex] = temp;
+  };
+
+  var len = items.length,
+  i, j, stop;
+
+  for (i=0; i < len; i++){
+    for (j=0, stop=len-i; j < stop; j++){
+      if (items[j] > items[j+1]){
+        swap(items, j, j+1);
+      }
+    }
+  }
+
+  return items;
+};

--- a/spec/go-to-line-spec.coffee
+++ b/spec/go-to-line-spec.coffee
@@ -8,6 +8,11 @@ describe 'GoToLine', ->
       atom.workspace.open('sample.js')
 
     runs ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      workspaceElement.style.height = "200px"
+      workspaceElement.style.widht = "1000px"
+      jasmine.attachToDOM(workspaceElement)
+
       editor = atom.workspace.getActiveTextEditor()
       editorView = atom.views.getView(editor)
       goToLine = GoToLineView.activate()
@@ -37,15 +42,25 @@ describe 'GoToLine', ->
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(editor.getCursorBufferPosition()).toEqual [2, 13]
 
-  describe "when entering a line number greater than the number in the buffer", ->
+    it "centers the selected line", ->
+      goToLine.miniEditor.getModel().insertText '45:4'
+      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
+      rowsPerPage = editor.getRowsPerPage()
+      currentRow = (editor.getCursorBufferPosition().row) - 1
+      expect(editor.getVisibleRowRange()).toEqual [
+        currentRow - Math.floor(rowsPerPage / 2) - 1, # do not include the current row
+        currentRow + Math.floor(rowsPerPage / 2)
+      ]
+
+  describe "when entering a line number greater than the number of rows in the buffer", ->
     it "moves the cursor position to the first character of the last line", ->
       atom.commands.dispatch editorView, 'go-to-line:toggle'
       expect(goToLine.panel.isVisible()).toBeTruthy()
       expect(goToLine.miniEditor.getText()).toBe ''
-      goToLine.miniEditor.getModel().insertText '14'
+      goToLine.miniEditor.getModel().insertText '71'
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(goToLine.panel.isVisible()).toBeFalsy()
-      expect(editor.getCursorBufferPosition()).toEqual [12, 0]
+      expect(editor.getCursorBufferPosition()).toEqual [70, 0]
 
   describe "when entering a column number greater than the number in the specified line", ->
     it "moves the cursor position to the last character of the specified line", ->


### PR DESCRIPTION
I did some digging in the Atom codebase and learned that Atom buffers some UI operations such as scrolling and changing the cursor before actually updating the UI.
Atom just renders the final result at the end. It turns out the option `{ center: true }` gets lost at some point.

This seemed like the quickest fix. But I wonder if there's a bug on Atom core, regarding the way it flushes all these UI operations.

Fixes https://github.com/atom/go-to-line/issues/29