### PR TITLE
Go-to-line without enter and cancel go-to

### DIFF
--- a/spec/go-to-line-spec.coffee
+++ b/spec/go-to-line-spec.coffee
@@ -39,11 +39,13 @@ describe 'GoToLine', ->
     it "moves the cursor to the column number of the line specified", ->
       expect(goToLine.miniEditor.getText()).toBe ''
       goToLine.miniEditor.getModel().insertText '3:14'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(editor.getCursorBufferPosition()).toEqual [2, 13]
 
     it "centers the selected line", ->
       goToLine.miniEditor.getModel().insertText '45:4'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       rowsPerPage = editor.getRowsPerPage()
       currentRow = (editor.getCursorBufferPosition().row) - 1
@@ -58,6 +60,7 @@ describe 'GoToLine', ->
       expect(goToLine.panel.isVisible()).toBeTruthy()
       expect(goToLine.miniEditor.getText()).toBe ''
       goToLine.miniEditor.getModel().insertText '71'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(goToLine.panel.isVisible()).toBeFalsy()
       expect(editor.getCursorBufferPosition()).toEqual [70, 0]
@@ -68,6 +71,7 @@ describe 'GoToLine', ->
       expect(goToLine.panel.isVisible()).toBeTruthy()
       expect(goToLine.miniEditor.getText()).toBe ''
       goToLine.miniEditor.getModel().insertText '3:43'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(goToLine.panel.isVisible()).toBeFalsy()
       expect(editor.getCursorBufferPosition()).toEqual [2, 40]
@@ -76,6 +80,7 @@ describe 'GoToLine', ->
     describe "when a line number has been entered", ->
       it "moves the cursor to the first character of the line", ->
         goToLine.miniEditor.getModel().insertText '3'
+        advanceClock(editor.buffer.stoppedChangingDelay)
         atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
         expect(editor.getCursorBufferPosition()).toEqual [2, 4]
 
@@ -88,6 +93,7 @@ describe 'GoToLine', ->
         # buffer rows are 0-indexed whereas the gutter row numbers are 1-indexed
         # so buffer row 6 corresponds to gutter row 7
         goToLine.miniEditor.getModel().insertText '7'
+        advanceClock(editor.buffer.stoppedChangingDelay)
         atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
         expect(editor.getCursorBufferPosition()).toEqual [6, 6]
 
@@ -104,12 +110,14 @@ describe 'GoToLine', ->
       atom.commands.dispatch editorView, 'go-to-line:toggle'
       expect(goToLine.panel.isVisible()).toBeTruthy()
       goToLine.miniEditor.getModel().insertText '4:1'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(goToLine.panel.isVisible()).toBeFalsy()
       expect(editor.getCursorBufferPosition()).toEqual [3, 0]
       atom.commands.dispatch editorView, 'go-to-line:toggle'
       expect(goToLine.panel.isVisible()).toBeTruthy()
       goToLine.miniEditor.getModel().insertText ':19'
+      advanceClock(editor.buffer.stoppedChangingDelay)
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(goToLine.panel.isVisible()).toBeFalsy()
       expect(editor.getCursorBufferPosition()).toEqual [3, 18]
@@ -121,3 +129,35 @@ describe 'GoToLine', ->
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:cancel')
       expect(goToLine.panel.isVisible()).toBeFalsy()
       expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+  describe "when entering a line number with delay and without confirm", ->
+    it "cursor should navigate to the line number", ->
+      atom.commands.dispatch editorView, 'go-to-line:toggle'
+      expect(goToLine.panel.isVisible()).toBeTruthy()
+      goToLine.miniEditor.getModel().insertText '5'
+      advanceClock(editor.buffer.stoppedChangingDelay)
+      expect(goToLine.panel.isVisible()).toBeTruthy()
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+      goToLine.miniEditor.getModel().insertText '1'
+      advanceClock(editor.buffer.stoppedChangingDelay)
+      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
+      expect(goToLine.panel.isVisible()).toBeFalsy()
+      expect(editor.getCursorBufferPosition()).toEqual [50, 0]
+
+  describe "when line number is entered and cancelled", ->
+    it "cursor should navigate to the initial position before navigation", ->
+      atom.commands.dispatch editorView, 'go-to-line:toggle'
+      expect(goToLine.panel.isVisible()).toBeTruthy()
+      goToLine.miniEditor.getModel().insertText '51'
+      advanceClock(editor.buffer.stoppedChangingDelay)
+      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
+      expect(goToLine.panel.isVisible()).toBeFalsy()
+      expect(editor.getCursorBufferPosition()).toEqual [50, 0]
+      atom.commands.dispatch editorView, 'go-to-line:toggle'
+      expect(goToLine.panel.isVisible()).toBeTruthy()
+      goToLine.miniEditor.getModel().insertText '20'
+      advanceClock(editor.buffer.stoppedChangingDelay)
+      expect(editor.getCursorBufferPosition()).toEqual [19, 4]
+      atom.commands.dispatch(goToLine.miniEditor.element, 'core:cancel')
+      expect(goToLine.panel.isVisible()).toBeFalsy()
+      expect(editor.getCursorBufferPosition()).toEqual [50, 0]


### PR DESCRIPTION
Implementation of **Dont wait till user presses Enter button** #26, inspired by #32.

Auto-navigation when go-to-line miniEditor model stops changing. Also, undo navigation on cancel and enter for confirmed navigation to a given line.

![atom-auto-nav](https://cloud.githubusercontent.com/assets/614105/19628254/50cc1066-9977-11e6-9043-20f34b90f2e5.gif)
