### PR TITLE
Tweak tests to accommodate the new editor rendering layer

### DIFF
--- a/spec/go-to-line-spec.js
+++ b/spec/go-to-line-spec.js
@@ -61,8 +61,9 @@ describe('GoToLine', () => {
       goToLine.miniEditor.insertText('45:4')
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       const rowsPerPage = editor.getRowsPerPage()
-      const currentRow = (editor.getCursorBufferPosition().row) - 1
-      expect(editor.getVisibleRowRange()).toEqual([currentRow - Math.floor(rowsPerPage / 2) - 1, currentRow + Math.floor(rowsPerPage / 2)])
+      const currentRow = editor.getCursorBufferPosition().row - 1
+      expect(editor.getFirstVisibleScreenRow()).toBe(currentRow - Math.ceil(rowsPerPage / 2))
+      expect(editor.getLastVisibleScreenRow()).toBe(currentRow + Math.floor(rowsPerPage / 2))
     })
   })
 

--- a/spec/go-to-line-spec.js
+++ b/spec/go-to-line-spec.js
@@ -17,7 +17,7 @@ describe('GoToLine', () => {
     runs(() => {
       const workspaceElement = atom.views.getView(atom.workspace)
       workspaceElement.style.height = '200px'
-      workspaceElement.style.widht = '1000px'
+      workspaceElement.style.width = '1000px'
       jasmine.attachToDOM(workspaceElement)
       editor = atom.workspace.getActiveTextEditor()
       editorView = atom.views.getView(editor)
@@ -56,7 +56,8 @@ describe('GoToLine', () => {
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       expect(editor.getCursorBufferPosition()).toEqual([2, 13])
     })
-    return it('centers the selected line', () => {
+
+    it('centers the selected line', () => {
       goToLine.miniEditor.insertText('45:4')
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm')
       const rowsPerPage = editor.getRowsPerPage()
@@ -66,7 +67,7 @@ describe('GoToLine', () => {
   })
 
   describe('when entering a line number greater than the number of rows in the buffer', () => {
-    return it('moves the cursor position to the first character of the last line', () => {
+    it('moves the cursor position to the first character of the last line', () => {
       atom.commands.dispatch(editorView, 'go-to-line:toggle')
       expect(goToLine.panel.isVisible()).toBeTruthy()
       expect(goToLine.miniEditor.getText()).toBe('')
@@ -97,6 +98,7 @@ describe('GoToLine', () => {
         expect(editor.getCursorBufferPosition()).toEqual([2, 4])
       })
     })
+
     describe('when the line number entered is nested within foldes', () => {
       it('unfolds all folds containing the given row', () => {
         expect(editor.indentationForBufferRow(6)).toEqual(3)
@@ -135,6 +137,7 @@ describe('GoToLine', () => {
       expect(editor.getCursorBufferPosition()).toEqual([3, 18])
     })
   })
+
   describe('when core:cancel is triggered', () => {
     it('closes the view and does not update the cursor position', () => {
       atom.commands.dispatch(editorView, 'go-to-line:toggle')


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/13880

Other than removing some cruft related to a previous coffee-script conversion, this pull request tweaks tests so that they continue working after the aforementioned pull request lands. It's quite minor, so I am going to 🚢 this right after we get a green build against the current stable and beta.