### PR TITLE
add support for relative line numbers

### DIFF
--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -64,10 +64,12 @@ class GoToLineView {
     let row = currentRow
     if (rowLineNumber.length > 0) {
       if (rowLineNumber[0] === '-') {
+        if (rowLineNumber.length === 1) return
         // Go backward
         const delta = parseInt(rowLineNumber.substring(1))
         row = currentRow - delta
       } else if (rowLineNumber[0] === '+' || rowLineNumber[0] === '=') {
+        if (rowLineNumber.length === 1) return
         // Go forward
         const delta = parseInt(rowLineNumber.substring(1))
         row = currentRow + delta

--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -34,7 +34,7 @@ class GoToLineView {
         if (arg.text.match(/[^0-9:]/)) {
           arg.cancel()
         }
-      } else if (arg.text.match(/[^0-9:\-\+=]/)) {
+      } else if (arg.text.match(/[^0-9:\-+=]/)) {
         arg.cancel()
       }
     })
@@ -65,11 +65,11 @@ class GoToLineView {
     if (rowLineNumber.length > 0) {
       if (rowLineNumber[0] === '-') {
         // Go backward
-        delta = parseInt(rowLineNumber.substring(1))
+        const delta = parseInt(rowLineNumber.substring(1))
         row = currentRow - delta
       } else if (rowLineNumber[0] === '+' || rowLineNumber[0] === '=') {
         // Go forward
-        delta = parseInt(rowLineNumber.substring(1))
+        const delta = parseInt(rowLineNumber.substring(1))
         row = currentRow + delta
       } else {
         // Absolute line number

--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -30,7 +30,11 @@ class GoToLineView {
       this.close()
     })
     this.miniEditor.onWillInsertText((arg) => {
-      if (arg.text.match(/[^0-9:]/)) {
+      if (this.miniEditor.getText().length > 0) {
+        if (arg.text.match(/[^0-9:]/)) {
+          arg.cancel()
+        }
+      } else if (arg.text.match(/[^0-9:\-\+=]/)) {
         arg.cancel()
       }
     })
@@ -57,7 +61,22 @@ class GoToLineView {
 
     const currentRow = editor.getCursorBufferPosition().row
     const rowLineNumber = lineNumber.split(/:+/)[0] || ''
-    const row = rowLineNumber.length > 0 ? parseInt(rowLineNumber) - 1 : currentRow
+    let row = currentRow
+    if (rowLineNumber.length > 0) {
+      if (rowLineNumber[0] === '-') {
+        // Go backward
+        delta = parseInt(rowLineNumber.substring(1))
+        row = currentRow - delta
+      } else if (rowLineNumber[0] === '+' || rowLineNumber[0] === '=') {
+        // Go forward
+        delta = parseInt(rowLineNumber.substring(1))
+        row = currentRow + delta
+      } else {
+        // Absolute line number
+        row = parseInt(rowLineNumber) - 1
+      }
+    }
+
     const columnLineNumber = lineNumber.split(/:+/)[1] || ''
     const column = columnLineNumber.length > 0 ? parseInt(columnLineNumber) - 1 : -1
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add support for going to a line based on relative line numbers (deltas). This is particularly useful in combination with packages such as [relative-numbers](https://atom.io/packages/relative-numbers) which displays the relative line numbers. The relative line numbers will be recognized by `-`/`+`/`=` prefixes. For example, "-4" is interpreted as go backward by 4 lines. (`=` is synonymous with `+` for convenience) 

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Faster code navigation.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Complicates the line number parsing slightly.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#50 

<!-- Enter any applicable Issues here -->
