### PR TITLE
Updated the shortcut so it's consistent across all platforms

### DIFF
--- a/keymaps/go-to-line.cson
+++ b/keymaps/go-to-line.cson
@@ -1,4 +1,7 @@
-'.platform-darwin, .platform-win32, .platform-linux':
+'.platform-darwin':
+  'cmd-g': 'go-to-line:toggle'
+
+'.platform-win32, .platform-linux':
   'ctrl-g': 'go-to-line:toggle'
 
 '.go-to-line atom-text-editor[mini]':


### PR DESCRIPTION
### Description of the Change

Hello everyone, 
This is my first PR to the atom ecosystem, even if it was really simple, I might have forgotten something.

So, most modules in atom have consistent shortcuts, fuzzy finding is `ctrl+p` on Windows and Linux, and `cmd+p` on Mac, etc.
This was not the case for this module, I'm not really sure why, especially since, on Mac, no other shortcut it tied to `cmd+g` by default.

I've now updated it so it uses `cmd+g` on Mac.

### Benefits

The shortcut are now consistent across all platforms, and in line with the other modules.

### Possible Drawbacks

This is a breaking change.

### Applicable Issues

I cannot see any, it does need to be added to the public changelog though.

Thank you,
Alvin
