### PR TITLE
Auto navigation changes came from PR https://github.com/atom/go-to-line/pull/32

### DIFF
--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -35,8 +35,8 @@ class GoToLineView {
       }
     })
     this.miniEditor.onDidChange(() => {
-      this.navigate({keepOpen: true});
-    });
+      this.navigate({keepOpen: true})
+    })
   }
 
   toggle () {
@@ -55,7 +55,7 @@ class GoToLineView {
   navigate (options) {
     const lineNumber = this.miniEditor.getText()
     const editor = atom.workspace.getActiveTextEditor()
-    if (options == null || options.keepOpen == null){
+    if (options == null || options.keepOpen == null) {
       this.close()
     }
     if (!editor || !lineNumber.length) return

--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -52,10 +52,10 @@ class GoToLineView {
     }
   }
 
-  navigate (options) {
+  navigate (options = {}) {
     const lineNumber = this.miniEditor.getText()
     const editor = atom.workspace.getActiveTextEditor()
-    if (options == null || options.keepOpen == null) {
+    if (!options.keepOpen) {
       this.close()
     }
     if (!editor || !lineNumber.length) return

--- a/lib/go-to-line-view.js
+++ b/lib/go-to-line-view.js
@@ -24,7 +24,7 @@ class GoToLineView {
       return false
     })
     atom.commands.add(this.miniEditor.element, 'core:confirm', () => {
-      this.confirm()
+      this.navigate()
     })
     atom.commands.add(this.miniEditor.element, 'core:cancel', () => {
       this.close()
@@ -34,6 +34,9 @@ class GoToLineView {
         arg.cancel()
       }
     })
+    this.miniEditor.onDidChange(() => {
+      this.navigate({keepOpen: true});
+    });
   }
 
   toggle () {
@@ -49,10 +52,12 @@ class GoToLineView {
     }
   }
 
-  confirm () {
+  navigate (options) {
     const lineNumber = this.miniEditor.getText()
     const editor = atom.workspace.getActiveTextEditor()
-    this.close()
+    if (options == null || options.keepOpen == null){
+      this.close()
+    }
     if (!editor || !lineNumber.length) return
 
     const currentRow = editor.getCursorBufferPosition().row

--- a/spec/go-to-line-spec.js
+++ b/spec/go-to-line-spec.js
@@ -49,6 +49,20 @@ describe('GoToLine', () => {
     })
   })
 
+  describe("when typing line numbers (auto-navigation)", () => {
+    it("automatically scrolls to the desired line", () => {
+      goToLine.miniEditor.insertText('13');
+      expect(editor.getCursorBufferPosition()).toEqual([12, 0]);
+    })
+  })
+
+  describe("when typing line and column numbers (auto-navigation)", () => {
+    it("automatically scrolls to the desired line and column", () => {
+      goToLine.miniEditor.insertText('3:8');
+      expect(editor.getCursorBufferPosition()).toEqual([2, 7]);
+    })
+  })
+
   describe('when entering a line number and column number', () => {
     it('moves the cursor to the column number of the line specified', () => {
       expect(goToLine.miniEditor.getText()).toBe('')

--- a/spec/go-to-line-spec.js
+++ b/spec/go-to-line-spec.js
@@ -49,17 +49,17 @@ describe('GoToLine', () => {
     })
   })
 
-  describe("when typing line numbers (auto-navigation)", () => {
-    it("automatically scrolls to the desired line", () => {
-      goToLine.miniEditor.insertText('13');
-      expect(editor.getCursorBufferPosition()).toEqual([12, 0]);
+  describe('when typing line numbers (auto-navigation)', () => {
+    it('automatically scrolls to the desired line', () => {
+      goToLine.miniEditor.insertText('13')
+      expect(editor.getCursorBufferPosition()).toEqual([12, 0])
     })
   })
 
-  describe("when typing line and column numbers (auto-navigation)", () => {
-    it("automatically scrolls to the desired line and column", () => {
-      goToLine.miniEditor.insertText('3:8');
-      expect(editor.getCursorBufferPosition()).toEqual([2, 7]);
+  describe('when typing line and column numbers (auto-navigation)', () => {
+    it('automatically scrolls to the desired line and column', () => {
+      goToLine.miniEditor.insertText('3:8')
+      expect(editor.getCursorBufferPosition()).toEqual([2, 7])
     })
   })
 


### PR DESCRIPTION



### Description of the Change

see https://github.com/atom/go-to-line/pull/32 for original PR.  This PR is adding the changes from the PR but after this package got converted from Coffeescript -> Javascript


### Benefits

Atom will navigate as you use go to line

### Possible Drawbacks


### Applicable Issues

https://github.com/atom/go-to-line/issues/26

/cc @nettofarah 
